### PR TITLE
Adding interrupt and fault records to a STF trace

### DIFF
--- a/core/observers/STFLogger.cpp
+++ b/core/observers/STFLogger.cpp
@@ -112,13 +112,136 @@ namespace pegasus
             }
         }
 
-        if (fault_cause_.isValid()
-            || interrupt_cause_.isValid()) // TODO: Add support for exceptions
+        if (fault_cause_.isValid())
         {
-            if (fault_cause_.getValue() == FaultCause::INST_ACCESS
-                || fault_cause_.getValue() == FaultCause::ILLEGAL_INST)
+            switch (fault_cause_.getValue())
             {
-                return;
+                case FaultCause::INST_ADDR_MISALIGNED:
+                    stf_writer_ << stf::EventRecord(stf::EventRecord::TYPE::INST_ADDR_MISALIGN,
+                                                    READ_CSR_REG<uint64_t>(state, MEPC));
+                    stf_writer_ << stf::EventPCTargetRecord(READ_CSR_REG<uint64_t>(state, MTVEC));
+                    return; // tied to invalid opcode
+                case FaultCause::INST_ACCESS:
+                    stf_writer_ << stf::EventRecord(stf::EventRecord::TYPE::INST_ADDR_FAULT,
+                                                    READ_CSR_REG<uint64_t>(state, MEPC));
+                    stf_writer_ << stf::EventPCTargetRecord(READ_CSR_REG<uint64_t>(state, MTVEC));
+                    return; // tied to invalid opcode
+                case FaultCause::INST_PAGE_FAULT:
+                    stf_writer_ << stf::EventRecord(
+                        stf::EventRecord::TYPE::INST_PAGE_FAULT,
+                        {READ_CSR_REG<uint64_t>(state, MEPC), state->getXlen()});
+                    stf_writer_ << stf::EventPCTargetRecord(READ_CSR_REG<uint64_t>(state, MTVEC));
+                    return; // tied to invalid opcode
+                case FaultCause::LOAD_ADDR_MISALIGNED:
+                    stf_writer_ << stf::EventRecord(stf::EventRecord::TYPE::LOAD_ADDR_MISALIGN,
+                                                    {READ_CSR_REG<uint64_t>(state, MEPC),
+                                                     state->getXlen(),
+                                                     READ_CSR_REG<uint64_t>(state, MTVAL)});
+                    stf_writer_ << stf::EventPCTargetRecord(READ_CSR_REG<uint64_t>(state, MTVEC));
+                    break;
+                case FaultCause::LOAD_ACCESS:
+                    stf_writer_ << stf::EventRecord(stf::EventRecord::TYPE::LOAD_ACCESS_FAULT,
+                                                    {READ_CSR_REG<uint64_t>(state, MEPC),
+                                                     state->getXlen(),
+                                                     READ_CSR_REG<uint64_t>(state, MTVAL)});
+                    stf_writer_ << stf::EventPCTargetRecord(READ_CSR_REG<uint64_t>(state, MTVEC));
+                    break;
+                case FaultCause::STORE_AMO_ADDR_MISALIGNED:
+                    stf_writer_ << stf::EventRecord(stf::EventRecord::TYPE::STORE_ADDR_MISALIGN,
+                                                    {READ_CSR_REG<uint64_t>(state, MEPC),
+                                                     state->getXlen(),
+                                                     READ_CSR_REG<uint64_t>(state, MTVAL)});
+                    stf_writer_ << stf::EventPCTargetRecord(READ_CSR_REG<uint64_t>(state, MTVEC));
+                    break;
+                case FaultCause::STORE_AMO_ACCESS:
+                    stf_writer_ << stf::EventRecord(stf::EventRecord::TYPE::STORE_ACCESS_FAULT,
+                                                    {READ_CSR_REG<uint64_t>(state, MEPC),
+                                                     state->getXlen(),
+                                                     READ_CSR_REG<uint64_t>(state, MTVAL)});
+                    stf_writer_ << stf::EventPCTargetRecord(READ_CSR_REG<uint64_t>(state, MTVEC));
+                    break;
+                case FaultCause::LOAD_PAGE_FAULT:
+                    stf_writer_ << stf::EventRecord(stf::EventRecord::TYPE::LOAD_PAGE_FAULT,
+                                                    {READ_CSR_REG<uint64_t>(state, MEPC),
+                                                     state->getXlen(),
+                                                     READ_CSR_REG<uint64_t>(state, MTVAL)});
+                    stf_writer_ << stf::EventPCTargetRecord(READ_CSR_REG<uint64_t>(state, MTVEC));
+                    break;
+                case FaultCause::STORE_AMO_PAGE_FAULT:
+                    stf_writer_ << stf::EventRecord(stf::EventRecord::TYPE::STORE_PAGE_FAULT,
+                                                    {READ_CSR_REG<uint64_t>(state, MEPC),
+                                                     state->getXlen(),
+                                                     READ_CSR_REG<uint64_t>(state, MTVAL)});
+                    stf_writer_ << stf::EventPCTargetRecord(READ_CSR_REG<uint64_t>(state, MTVEC));
+                    return; // tied to invalid opcode
+                case FaultCause::ILLEGAL_INST:
+                    stf_writer_ << stf::EventRecord(stf::EventRecord::TYPE::ILLEGAL_INST,
+                                                    {READ_CSR_REG<uint64_t>(state, MEPC),
+                                                     READ_CSR_REG<uint64_t>(state, MTVAL),
+                                                     state->getXlen()});
+                    stf_writer_ << stf::EventPCTargetRecord(READ_CSR_REG<uint64_t>(state, MTVEC));
+                    break;
+                case FaultCause::BREAKPOINT:
+                    stf_writer_ << stf::EventRecord(stf::EventRecord::TYPE::BREAKPOINT,
+                                                    READ_CSR_REG<uint64_t>(state, MEPC));
+                    stf_writer_ << stf::EventPCTargetRecord(READ_CSR_REG<uint64_t>(state, MTVEC));
+                    break;
+                case FaultCause::USER_ECALL:
+                    stf_writer_ << stf::EventRecord(stf::EventRecord::TYPE::USER_ECALL,
+                                                    READ_INT_REG<uint64_t>(state, 17));
+                    stf_writer_ << stf::EventPCTargetRecord(READ_CSR_REG<uint64_t>(state, MTVEC));
+                    break;
+                case FaultCause::SUPERVISOR_ECALL:
+                    stf_writer_ << stf::EventRecord(stf::EventRecord::TYPE::SUPERVISOR_ECALL,
+                                                    READ_INT_REG<uint64_t>(state, 17));
+                    stf_writer_ << stf::EventPCTargetRecord(READ_CSR_REG<uint64_t>(state, MTVEC));
+                    break;
+                case FaultCause::MACHINE_ECALL:
+                    stf_writer_ << stf::EventRecord(stf::EventRecord::TYPE::MACHINE_ECALL,
+                                                    READ_INT_REG<uint64_t>(state, 17));
+                    stf_writer_ << stf::EventPCTargetRecord(READ_CSR_REG<uint64_t>(state, MTVEC));
+                    break;
+                default:
+                    sparta_assert(false, "STFLogger: Unknown fault cause");
+            }
+        }
+        else if (interrupt_cause_.isValid())
+        {
+            switch (interrupt_cause_.getValue())
+            {
+                case InterruptCause::SUPERVISOR_SOFTWARE:
+                    stf_writer_ << stf::EventRecord(stf::EventRecord::TYPE::INT_SUPERVISOR_SOFTWARE,
+                                                    {0});
+                    stf_writer_ << stf::EventPCTargetRecord(READ_CSR_REG<uint64_t>(state, MTVEC));
+                    break;
+                case InterruptCause::MACHINE_SOFTWARE:
+                    stf_writer_ << stf::EventRecord(stf::EventRecord::TYPE::INT_MACHINE_SOFTWARE,
+                                                    {0});
+                    stf_writer_ << stf::EventPCTargetRecord(READ_CSR_REG<uint64_t>(state, MTVEC));
+                    break;
+                case InterruptCause::SUPERVISOR_TIMER:
+                    stf_writer_ << stf::EventRecord(stf::EventRecord::TYPE::INT_SUPERVISOR_TIMER,
+                                                    {0});
+                    stf_writer_ << stf::EventPCTargetRecord(READ_CSR_REG<uint64_t>(state, MTVEC));
+                    break;
+                case InterruptCause::MACHINE_TIMER:
+                    stf_writer_ << stf::EventRecord(stf::EventRecord::TYPE::INT_MACHINE_TIMER, {0});
+                    stf_writer_ << stf::EventPCTargetRecord(READ_CSR_REG<uint64_t>(state, MTVEC));
+                    break;
+                case InterruptCause::SUPERVISOR_EXTERNAL:
+                    stf_writer_ << stf::EventRecord(stf::EventRecord::TYPE::INT_USER_EXT, {0});
+                    stf_writer_ << stf::EventPCTargetRecord(READ_CSR_REG<uint64_t>(state, MTVEC));
+                    break;
+                case InterruptCause::MACHINE_EXTERNAL:
+                    stf_writer_ << stf::EventRecord(stf::EventRecord::TYPE::INT_MACHINE_EXT, {0});
+                    stf_writer_ << stf::EventPCTargetRecord(READ_CSR_REG<uint64_t>(state, MTVEC));
+                    break;
+                case InterruptCause::COUNTER_OVERFLOW:
+                    stf_writer_ << stf::EventRecord(stf::EventRecord::TYPE::INT_USER_SOFTWARE, {0});
+                    stf_writer_ << stf::EventPCTargetRecord(READ_CSR_REG<uint64_t>(state, MTVEC));
+                    break;
+                default:
+                    sparta_assert(false, "STFLogger: Unknown interrupt");
             }
         }
         else if (state->getNextPc()


### PR DESCRIPTION
This PR adds interrupt and fault information to a STF trace using Event and EventPCTarget records.