### PR TITLE
v_ext: fix vfirst inst

### DIFF
--- a/core/inst_handlers/v/RvvMaskInsts.cpp
+++ b/core/inst_handlers/v/RvvMaskInsts.cpp
@@ -159,6 +159,10 @@ namespace pegasus
                 tmp.pokeVal(elems_vs2.getElement(index).getVal()
                             & elems_v0.getElement(index).getVal());
             }
+            else
+            {
+                tmp.getVal();
+            }
             for (auto bit_iter = tmp.begin(); bit_iter != tmp.end(); ++bit_iter)
             {
                 WRITE_INT_REG<XLEN>(state, inst->getRd(),


### PR DESCRIPTION
now there should be no trace differences from `rv_v_xlen_256_vlmul_m1_rv64v_0.zstf`.