### PR TITLE
Zilsd Extension (RV32 Only)

### DIFF
--- a/arch/CMakeLists.txt
+++ b/arch/CMakeLists.txt
@@ -78,7 +78,7 @@ add_custom_command(
 
 add_custom_command(
   OUTPUT ${AUTOGEN_RV64_INST_JSON_FILES}
-  COMMAND python3 ${SIM_BASE}/scripts/GenInstructionJSON.py rv64imafdbv_zicsr_zifencei_zicbop_zicbom_zicboz_zicond_zcmp_zihintntl_zihintpause
+  COMMAND python3 ${SIM_BASE}/scripts/GenInstructionJSON.py rv64imafdbv_zicsr_zifencei_zicbop_zicbom_zicboz_zicond_zcmp_zilsd_zihintntl_zihintpause
   DEPENDS ${DEPENDS_INST_JSON_FILES}
 )
 

--- a/arch/CMakeLists.txt
+++ b/arch/CMakeLists.txt
@@ -72,7 +72,7 @@ file(GLOB DEPENDS_INST_JSON_FILES ${SIM_BASE}/scripts/insts/RV*.py)
 
 add_custom_command(
   OUTPUT ${AUTOGEN_RV32_INST_JSON_FILES}
-  COMMAND python3 ${SIM_BASE}/scripts/GenInstructionJSON.py rv32imafdbv_zicsr_zifencei_zicbop_zicbom_zicboz_zicond_zcmp_zihintntl_zihintpause
+  COMMAND python3 ${SIM_BASE}/scripts/GenInstructionJSON.py rv32imafdbv_zicsr_zifencei_zicbop_zicbom_zicboz_zicond_zcmp_zilsd_zihintntl_zihintpause
   DEPENDS ${DEPENDS_INST_JSON_FILES}
 )
 

--- a/core/Execute.cpp
+++ b/core/Execute.cpp
@@ -19,6 +19,7 @@
 #include "core/inst_handlers/zifencei/RvzifenceiInsts.hpp"
 #include "core/inst_handlers/zicond/RvzicondInsts.hpp"
 #include "core/inst_handlers/zcmp/RvzcmpInsts.hpp"
+#include "core/inst_handlers/zilsd/RvzilsdInsts.hpp"
 #include "core/inst_handlers/v/RvvConfigSettingInsts.hpp"
 #include "core/inst_handlers/v/RvvIntegerInsts.hpp"
 #include "core/inst_handlers/v/RvvLoadStoreInsts.hpp"
@@ -91,6 +92,7 @@ namespace pegasus
         RvzifenceiInsts::getInstHandlers<RV32>(rv32_inst_actions_);
         RvzicondInsts::getInstHandlers<RV32>(rv32_inst_actions_);
         RvzcmpInsts::getInstHandlers<RV32>(rv32_inst_actions_);
+        RvzilsdInsts::getInstHandlers<RV32>(rv32_inst_actions_);
         RvvConfigSettingInsts::getInstHandlers<RV32>(rv32_inst_actions_);
         RvvIntegerInsts::getInstHandlers<RV32>(rv32_inst_actions_);
         RvvLoadStoreInsts::getInstHandlers<RV32>(rv32_inst_actions_);
@@ -111,6 +113,7 @@ namespace pegasus
         RvaInsts::getInstComputeAddressHandlers<RV32>(rv32_inst_compute_address_actions_);
         RvfInsts::getInstComputeAddressHandlers<RV32>(rv32_inst_compute_address_actions_);
         RvdInsts::getInstComputeAddressHandlers<RV32>(rv32_inst_compute_address_actions_);
+        RvzilsdInsts::getInstComputeAddressHandlers<RV32>(rv32_inst_compute_address_actions_);
         RvvLoadStoreInsts::getInstComputeAddressHandlers<RV32>(rv32_inst_compute_address_actions_);
 
         // Get CSR update handlers

--- a/core/PegasusState.cpp
+++ b/core/PegasusState.cpp
@@ -326,7 +326,8 @@ namespace pegasus
             xlen_uarch_file_path + "/pegasus_uarch_rv" + xlen_str + "zicbom.json",
             xlen_uarch_file_path + "/pegasus_uarch_rv" + xlen_str + "zicboz.json",
             xlen_uarch_file_path + "/pegasus_uarch_rv" + xlen_str + "zicond.json",
-            xlen_uarch_file_path + "/pegasus_uarch_rv" + xlen_str + "zcmp.json"};
+            xlen_uarch_file_path + "/pegasus_uarch_rv" + xlen_str + "zcmp.json",
+            xlen_uarch_file_path + "/pegasus_uarch_rv" + xlen_str + "zilsd.json"};
         return uarch_files;
     }
 

--- a/core/inst_handlers/CMakeLists.txt
+++ b/core/inst_handlers/CMakeLists.txt
@@ -3,14 +3,15 @@ project(Pegasus)
 add_subdirectory(i)
 add_subdirectory(m)
 add_subdirectory(a)
-add_subdirectory(b)
 add_subdirectory(f)
 add_subdirectory(d)
+add_subdirectory(b)
 add_subdirectory(v)
 add_subdirectory(zicsr)
 add_subdirectory(zifencei)
 add_subdirectory(zicond)
 add_subdirectory(zcmp)
+add_subdirectory(zilsd)
 
 add_library(pegasusinsts)
 target_link_libraries(pegasusinsts
@@ -20,10 +21,11 @@ target_link_libraries(pegasusinsts
     rvf
     rvd
     rvb
+    rvv
     rvzicsr
     rvzifencei
     rvzicond
     rvzcmp
-    rvv
+    rvzilsd
 )
 add_dependencies(pegasusinsts AutogenArchFiles)

--- a/core/inst_handlers/zilsd/CMakeLists.txt
+++ b/core/inst_handlers/zilsd/CMakeLists.txt
@@ -1,0 +1,8 @@
+project(Pegasus)
+
+file(GLOB SOURCES "${CMAKE_CURRENT_LIST_DIR}/*.cpp")
+add_library(rvzilsd
+    OBJECT
+    ${SOURCES}
+)
+add_dependencies(rvzilsd AutogenArchFiles)

--- a/core/inst_handlers/zilsd/RvzilsdInsts.cpp
+++ b/core/inst_handlers/zilsd/RvzilsdInsts.cpp
@@ -75,7 +75,7 @@ namespace pegasus
 
         // Write bits 63:32 to the higher-numbered register
         const RV32 rd2_val = result >> 32;
-        WRITE_INT_REG<RV32>(state, inst->getRd() + 1, rd2_val);
+        WRITE_INT_REG<RV32>(state, inst->getRd2(), rd2_val);
 
         return ++action_it;
     }
@@ -87,11 +87,11 @@ namespace pegasus
         PegasusTranslationState* translation_state = inst->getTranslationState();
 
         const RV32 rs2_val = READ_INT_REG<RV32>(state, inst->getRs2());
-        const RV32 rs3_val = READ_INT_REG<RV32>(state, inst->getRs2() + 1);
+        const RV32 rs3_val = READ_INT_REG<RV32>(state, inst->getRs3());
         
         // lower-numbered register holds bits 31:0
         // higher-numbered register holds bits 63:32
-        uint64_t value = ((uint64_t)rs3_val << 32) & rs2_val;
+        const uint64_t value = ((uint64_t)rs3_val << 32) | rs2_val;
 
         const uint64_t paddr = translation_state->getResult().getPAddr();
         translation_state->popResult();

--- a/core/inst_handlers/zilsd/RvzilsdInsts.cpp
+++ b/core/inst_handlers/zilsd/RvzilsdInsts.cpp
@@ -1,0 +1,102 @@
+#include "core/inst_handlers/zilsd/RvzilsdInsts.hpp"
+#include "include/ActionTags.hpp"
+#include "core/ActionGroup.hpp"
+#include "core/PegasusState.hpp"
+#include "core/PegasusInst.hpp"
+
+namespace pegasus
+{
+    template <typename XLEN>
+    void RvzilsdInsts::getInstComputeAddressHandlers(std::map<std::string, Action> & inst_handlers)
+    {
+        static_assert(std::is_same_v<XLEN, RV32>);
+
+        inst_handlers.emplace(
+            "ld",
+            pegasus::Action::createAction<&RvzilsdInsts::computeAddressHandler_,
+                                          RvzilsdInsts>(nullptr, "ld",
+                                                      ActionTags::COMPUTE_ADDR_TAG));
+        inst_handlers.emplace(
+            "sd",
+            pegasus::Action::createAction<&RvzilsdInsts::computeAddressHandler_,
+                                          RvzilsdInsts>(nullptr, "sd",
+                                                      ActionTags::COMPUTE_ADDR_TAG));
+    }
+
+    template <typename XLEN>
+    void RvzilsdInsts::getInstHandlers(std::map<std::string, Action> & inst_handlers)
+    {
+        static_assert(std::is_same_v<XLEN, RV32>);
+
+        inst_handlers.emplace(
+            "ld",
+            pegasus::Action::createAction<&RvzilsdInsts::ldHandler_,
+                                          RvzilsdInsts>(nullptr, "ld", ActionTags::EXECUTE_TAG));
+        inst_handlers.emplace(
+            "sd",
+            pegasus::Action::createAction<&RvzilsdInsts::sdHandler_,
+                                          RvzilsdInsts>(nullptr, "sd", ActionTags::EXECUTE_TAG));
+    }
+
+    template void RvzilsdInsts::getInstComputeAddressHandlers<RV32>(std::map<std::string, Action> &);
+    template void RvzilsdInsts::getInstHandlers<RV32>(std::map<std::string, Action> &);
+
+    Action::ItrType RvzilsdInsts::computeAddressHandler_(pegasus::PegasusState* state,
+                                                       Action::ItrType action_it)
+    {
+        const PegasusInstPtr & inst = state->getCurrentInst();
+        PegasusTranslationState* translation_state = inst->getTranslationState();
+
+        // TODO: Do we need to check that the rd register number is valid?
+
+        const RV32 rs1_val = READ_INT_REG<RV32>(state, inst->getRs1());
+        const RV32 imm = inst->getImmediate();
+
+        const RV32 vaddr = rs1_val + imm;
+        translation_state->makeRequest(vaddr, sizeof(uint64_t));
+
+        return ++action_it;
+    }
+
+    Action::ItrType RvzilsdInsts::ldHandler_(pegasus::PegasusState* state,
+                                                 Action::ItrType action_it)
+    {
+        const PegasusInstPtr & inst = state->getCurrentInst();
+        PegasusTranslationState* translation_state = inst->getTranslationState();
+
+        const RV32 paddr = translation_state->getResult().getPAddr();
+        translation_state->popResult();
+        const uint64_t result = state->readMemory<uint64_t>(paddr);
+
+        // Write bits 31:0 to the lower-numbered register
+        const RV32 rd1_val = ((1ull << 33) - 1) & result;
+        WRITE_INT_REG<RV32>(state, inst->getRd(), rd1_val);
+
+
+        // Write bits 63:32 to the higher-numbered register
+        const RV32 rd2_val = result >> 32;
+        WRITE_INT_REG<RV32>(state, inst->getRd() + 1, rd2_val);
+
+        return ++action_it;
+    }
+
+    Action::ItrType RvzilsdInsts::sdHandler_(pegasus::PegasusState* state,
+                                                  Action::ItrType action_it)
+    {
+        const PegasusInstPtr & inst = state->getCurrentInst();
+        PegasusTranslationState* translation_state = inst->getTranslationState();
+
+        const RV32 rs2_val = READ_INT_REG<RV32>(state, inst->getRs2());
+        const RV32 rs3_val = READ_INT_REG<RV32>(state, inst->getRs2() + 1);
+        
+        // lower-numbered register holds bits 31:0
+        // higher-numbered register holds bits 63:32
+        uint64_t value = ((uint64_t)rs3_val << 32) & rs2_val;
+
+        const uint64_t paddr = translation_state->getResult().getPAddr();
+        translation_state->popResult();
+        state->writeMemory<uint64_t>(paddr, value);
+
+        return ++action_it;
+    }
+} // namespace pegasus

--- a/core/inst_handlers/zilsd/RvzilsdInsts.cpp
+++ b/core/inst_handlers/zilsd/RvzilsdInsts.cpp
@@ -47,8 +47,6 @@ namespace pegasus
         const PegasusInstPtr & inst = state->getCurrentInst();
         PegasusTranslationState* translation_state = inst->getTranslationState();
 
-        // TODO: Do we need to check that the rd register number is valid?
-
         const RV32 rs1_val = READ_INT_REG<RV32>(state, inst->getRs1());
         const RV32 imm = inst->getImmediate();
 
@@ -71,7 +69,6 @@ namespace pegasus
         // Write bits 31:0 to the lower-numbered register
         const RV32 rd1_val = ((1ull << 33) - 1) & result;
         WRITE_INT_REG<RV32>(state, inst->getRd(), rd1_val);
-
 
         // Write bits 63:32 to the higher-numbered register
         const RV32 rd2_val = result >> 32;

--- a/core/inst_handlers/zilsd/RvzilsdInsts.cpp
+++ b/core/inst_handlers/zilsd/RvzilsdInsts.cpp
@@ -13,14 +13,12 @@ namespace pegasus
 
         inst_handlers.emplace(
             "ld",
-            pegasus::Action::createAction<&RvzilsdInsts::computeAddressHandler_,
-                                          RvzilsdInsts>(nullptr, "ld",
-                                                      ActionTags::COMPUTE_ADDR_TAG));
+            pegasus::Action::createAction<&RvzilsdInsts::computeAddressHandler_, RvzilsdInsts>(
+                nullptr, "ld", ActionTags::COMPUTE_ADDR_TAG));
         inst_handlers.emplace(
             "sd",
-            pegasus::Action::createAction<&RvzilsdInsts::computeAddressHandler_,
-                                          RvzilsdInsts>(nullptr, "sd",
-                                                      ActionTags::COMPUTE_ADDR_TAG));
+            pegasus::Action::createAction<&RvzilsdInsts::computeAddressHandler_, RvzilsdInsts>(
+                nullptr, "sd", ActionTags::COMPUTE_ADDR_TAG));
     }
 
     template <typename XLEN>
@@ -29,20 +27,19 @@ namespace pegasus
         static_assert(std::is_same_v<XLEN, RV32>);
 
         inst_handlers.emplace(
-            "ld",
-            pegasus::Action::createAction<&RvzilsdInsts::ldHandler_,
-                                          RvzilsdInsts>(nullptr, "ld", ActionTags::EXECUTE_TAG));
+            "ld", pegasus::Action::createAction<&RvzilsdInsts::ldHandler_, RvzilsdInsts>(
+                      nullptr, "ld", ActionTags::EXECUTE_TAG));
         inst_handlers.emplace(
-            "sd",
-            pegasus::Action::createAction<&RvzilsdInsts::sdHandler_,
-                                          RvzilsdInsts>(nullptr, "sd", ActionTags::EXECUTE_TAG));
+            "sd", pegasus::Action::createAction<&RvzilsdInsts::sdHandler_, RvzilsdInsts>(
+                      nullptr, "sd", ActionTags::EXECUTE_TAG));
     }
 
-    template void RvzilsdInsts::getInstComputeAddressHandlers<RV32>(std::map<std::string, Action> &);
+    template void
+    RvzilsdInsts::getInstComputeAddressHandlers<RV32>(std::map<std::string, Action> &);
     template void RvzilsdInsts::getInstHandlers<RV32>(std::map<std::string, Action> &);
 
     Action::ItrType RvzilsdInsts::computeAddressHandler_(pegasus::PegasusState* state,
-                                                       Action::ItrType action_it)
+                                                         Action::ItrType action_it)
     {
         const PegasusInstPtr & inst = state->getCurrentInst();
         PegasusTranslationState* translation_state = inst->getTranslationState();
@@ -57,7 +54,7 @@ namespace pegasus
     }
 
     Action::ItrType RvzilsdInsts::ldHandler_(pegasus::PegasusState* state,
-                                                 Action::ItrType action_it)
+                                             Action::ItrType action_it)
     {
         const PegasusInstPtr & inst = state->getCurrentInst();
         PegasusTranslationState* translation_state = inst->getTranslationState();
@@ -78,14 +75,14 @@ namespace pegasus
     }
 
     Action::ItrType RvzilsdInsts::sdHandler_(pegasus::PegasusState* state,
-                                                  Action::ItrType action_it)
+                                             Action::ItrType action_it)
     {
         const PegasusInstPtr & inst = state->getCurrentInst();
         PegasusTranslationState* translation_state = inst->getTranslationState();
 
         const RV32 rs2_val = READ_INT_REG<RV32>(state, inst->getRs2());
         const RV32 rs3_val = READ_INT_REG<RV32>(state, inst->getRs3());
-        
+
         // lower-numbered register holds bits 31:0
         // higher-numbered register holds bits 63:32
         const uint64_t value = ((uint64_t)rs3_val << 32) | rs2_val;

--- a/core/inst_handlers/zilsd/RvzilsdInsts.hpp
+++ b/core/inst_handlers/zilsd/RvzilsdInsts.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "include/PegasusTypes.hpp"
+#include "core/Action.hpp"
+
+#include <map>
+
+namespace pegasus
+{
+    class PegasusState;
+    class Action;
+    class ActionGroup;
+
+    class RvzilsdInsts
+    {
+      public:
+        using base_type = RvzilsdInsts;
+
+        template <typename XLEN>
+        static void getInstComputeAddressHandlers(std::map<std::string, Action> &);
+        template <typename XLEN> static void getInstHandlers(std::map<std::string, Action> &);
+
+      private:
+        // ld and sd
+        Action::ItrType computeAddressHandler_(pegasus::PegasusState* state, Action::ItrType);
+        Action::ItrType ldHandler_(pegasus::PegasusState* state, Action::ItrType);
+        Action::ItrType sdHandler_(pegasus::PegasusState* state, Action::ItrType);
+    };
+} // namespace pegasus

--- a/scripts/GenInstructionJSON.py
+++ b/scripts/GenInstructionJSON.py
@@ -46,6 +46,7 @@ from insts.RVZCMP_INST import RV32ZCMP_INST
 from insts.RVZCMP_INST import RV64ZCMP_INST
 
 from insts.RVZILSD_INST import RV32ZILSD_INST
+from insts.RVZILSD_INST import RV64ZILSD_INST
 
 from insts.RVZVE64X_INST import RVZVE64X_INST
 from insts.RVZVE64D_INST import RVZVE64D_INST

--- a/scripts/GenInstructionJSON.py
+++ b/scripts/GenInstructionJSON.py
@@ -45,6 +45,8 @@ from insts.RVZICOND_INST import RV64ZICOND_INST
 from insts.RVZCMP_INST import RV32ZCMP_INST
 from insts.RVZCMP_INST import RV64ZCMP_INST
 
+from insts.RVZILSD_INST import RV32ZILSD_INST
+
 from insts.RVZVE64X_INST import RVZVE64X_INST
 from insts.RVZVE64D_INST import RVZVE64D_INST
 from insts.RVZVE32X_INST import RVZVE32X_INST

--- a/scripts/insts/RVZILSD_INST.py
+++ b/scripts/insts/RVZILSD_INST.py
@@ -1,0 +1,4 @@
+RV32ZILSD_INST = [
+    {'mnemonic': 'ld', 'handler': 'ld', 'cost': 1, 'tags': 'ZILSD_EXT_32', 'memory': True, 'cof': False},
+    {'mnemonic': 'sd', 'handler': 'sd', 'cost': 1, 'tags': 'ZILSD_EXT_32', 'memory': True, 'cof': False},
+]

--- a/scripts/insts/RVZILSD_INST.py
+++ b/scripts/insts/RVZILSD_INST.py
@@ -2,3 +2,5 @@ RV32ZILSD_INST = [
     {'mnemonic': 'ld', 'handler': 'ld', 'cost': 1, 'tags': 'ZILSD_EXT_32', 'memory': True, 'cof': False},
     {'mnemonic': 'sd', 'handler': 'sd', 'cost': 1, 'tags': 'ZILSD_EXT_32', 'memory': True, 'cof': False},
 ]
+
+RV64ZILSD_INST = []


### PR DESCRIPTION
This extension adds double word load and store support to RV32. The instructions per 64-bit memory operations with a pair of 32-bit registers.