### PR TITLE
Fixed Bug Where "g" Extension was Being Disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ FetchContent_MakeAvailable(spike)
 
 ################################################################################
 
-find_program(CLANGFORMAT_EXECUTABLE NAMES clang-format-14 clang-format)
+find_program(CLANGFORMAT_EXECUTABLE NAMES clang-format)
 
 execute_process (
   COMMAND
@@ -158,7 +158,7 @@ execute_process (
      CLANGFORMAT_VERSION_OUTPUT
 )
 
-set(REQUIRED_CLANGFORMAT_VERSION "14")
+set(REQUIRED_CLANGFORMAT_VERSION "15")
 
 # Extract the version number from the output
 string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" CLANGFORMAT_VERSION ${CLANGFORMAT_VERSION_OUTPUT})

--- a/core/inst_handlers/zicsr/RvzicsrInsts.cpp
+++ b/core/inst_handlers/zicsr/RvzicsrInsts.cpp
@@ -469,6 +469,9 @@ namespace pegasus
             const std::string ext_str = std::string(1, ext);
             if (ext_manager.isExtensionSupported(ext_str))
             {
+                // G bit is reserved
+                if (ext == 'g') { continue; }
+
                 if (misa_val & (1 << (ext - 'a')))
                 {
                     exts_to_enable.emplace_back(ext_str);

--- a/core/inst_handlers/zicsr/RvzicsrInsts.cpp
+++ b/core/inst_handlers/zicsr/RvzicsrInsts.cpp
@@ -470,7 +470,10 @@ namespace pegasus
             if (ext_manager.isExtensionSupported(ext_str))
             {
                 // G bit is reserved
-                if (ext == 'g') { continue; }
+                if (ext == 'g')
+                {
+                    continue;
+                }
 
                 if (misa_val & (1 << (ext - 'a')))
                 {


### PR DESCRIPTION
In the MISA register, the "g" bit is reserved. Fixed a bug where MISA update handler was trying to disable the "g" extension through the ExtensionManager. Also updated required clangformat version to 15.