### PR TITLE
Ensure DB-recreated events are validated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,11 @@ IDE/backend/__pycache__/**
 IDE/editor/__pycache__/**
 .spike_commit_log
 gen/
+include/CSRBitMasks32.hpp
+include/CSRBitMasks64.hpp
+include/CSRFieldIdxs32.hpp
+include/CSRFieldIdxs64.hpp
+CSRHelpers.hpp
+CSRNums.hpp
+arch/rv32/**
+arch/rv64/**

--- a/.gitignore
+++ b/.gitignore
@@ -12,11 +12,3 @@ IDE/backend/__pycache__/**
 IDE/editor/__pycache__/**
 .spike_commit_log
 gen/
-include/CSRBitMasks32.hpp
-include/CSRBitMasks64.hpp
-include/CSRFieldIdxs32.hpp
-include/CSRFieldIdxs64.hpp
-CSRHelpers.hpp
-CSRNums.hpp
-arch/rv32/**
-arch/rv64/**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,6 @@ target_compile_options (pegasuslibs INTERFACE -Werror
     -Woverloaded-virtual -Wunused-parameter -Wmissing-field-initializers -pipe)
 
 # Use lld for linking clang and gcc builds
-# Use lld for linking clang and gcc builds
 if (NOT APPLE)
   target_link_options(pegasuslibs INTERFACE -fuse-ld=lld)
 endif ()

--- a/cosim/CoSimPipeline.cpp
+++ b/cosim/CoSimPipeline.cpp
@@ -32,6 +32,10 @@ namespace pegasus::cosim
     void CoSimPipeline::setNumHarts(size_t num_harts) { hart_pipelines_.reserve(num_harts); }
 
     ////////////////////////////////////////////////////////////////////////////////////////
+    void CoSimPipeline::setEventCacheSize(size_t event_window_size)
+    { event_window_size_ = event_window_size; }
+
+    ////////////////////////////////////////////////////////////////////////////////////////
     std::unique_ptr<simdb::pipeline::Pipeline>
     CoSimPipeline::createPipeline(simdb::pipeline::AsyncDatabaseAccessor* db_accessor)
     {
@@ -67,10 +71,10 @@ namespace pegasus::cosim
                     return false;
                 });
 
-            // Run the events through a 100-to-1 buffer
+            // Run the events through a buffer
             constexpr bool flush_partial = true;
             auto source_buffer =
-                simdb::pipeline::createTask<simdb::pipeline::Buffer<Event>>(100, flush_partial);
+                simdb::pipeline::createTask<simdb::pipeline::Buffer<Event>>(event_window_size_, flush_partial);
 
             // Pre-validated "range" of events (euid auto-inc by 1 in the event vector)
             using ConvertToRangeFunction = simdb::pipeline::Function<EventBuffer, EventsRange>;
@@ -281,6 +285,7 @@ namespace pegasus::cosim
             std::cout << "    From disk:  0\n\n";
         }
 
+        //TODO cnyce: Remove this flag when map_v2.1.3 is available
         torn_down_ = true;
     }
 

--- a/cosim/CoSimPipeline.cpp
+++ b/cosim/CoSimPipeline.cpp
@@ -41,7 +41,8 @@ namespace pegasus::cosim
 
         for (HartId hart_id = 0; hart_id < hart_pipelines_.capacity(); ++hart_id)
         {
-            hart_pipelines_.emplace_back(std::make_unique<CoSimHartPipeline>(db_mgr_, db_accessor, hart_id));
+            hart_pipelines_.emplace_back(
+                std::make_unique<CoSimHartPipeline>(db_mgr_, db_accessor, hart_id));
             auto hart_pipeline = hart_pipelines_.at(hart_id).get();
 
             pipeline_input_queues_.emplace_back(std::make_unique<simdb::ConcurrentQueue<Event>>());
@@ -68,7 +69,8 @@ namespace pegasus::cosim
 
             // Run the events through a 100-to-1 buffer
             constexpr bool flush_partial = true;
-            auto source_buffer = simdb::pipeline::createTask<simdb::pipeline::Buffer<Event>>(100, flush_partial);
+            auto source_buffer =
+                simdb::pipeline::createTask<simdb::pipeline::Buffer<Event>>(100, flush_partial);
 
             // Pre-validated "range" of events (euid auto-inc by 1 in the event vector)
             using ConvertToRangeFunction = simdb::pipeline::Function<EventBuffer, EventsRange>;

--- a/cosim/CoSimPipeline.cpp
+++ b/cosim/CoSimPipeline.cpp
@@ -32,7 +32,7 @@ namespace pegasus::cosim
     void CoSimPipeline::setNumHarts(size_t num_harts) { hart_pipelines_.reserve(num_harts); }
 
     ////////////////////////////////////////////////////////////////////////////////////////
-    void CoSimPipeline::setEventCacheSize(size_t event_window_size)
+    void CoSimPipeline::setEventWindowSize(size_t event_window_size)
     {
         event_window_size_ = event_window_size;
     }

--- a/cosim/CoSimPipeline.cpp
+++ b/cosim/CoSimPipeline.cpp
@@ -33,7 +33,9 @@ namespace pegasus::cosim
 
     ////////////////////////////////////////////////////////////////////////////////////////
     void CoSimPipeline::setEventCacheSize(size_t event_window_size)
-    { event_window_size_ = event_window_size; }
+    {
+        event_window_size_ = event_window_size;
+    }
 
     ////////////////////////////////////////////////////////////////////////////////////////
     std::unique_ptr<simdb::pipeline::Pipeline>
@@ -73,8 +75,8 @@ namespace pegasus::cosim
 
             // Run the events through a buffer
             constexpr bool flush_partial = true;
-            auto source_buffer =
-                simdb::pipeline::createTask<simdb::pipeline::Buffer<Event>>(event_window_size_, flush_partial);
+            auto source_buffer = simdb::pipeline::createTask<simdb::pipeline::Buffer<Event>>(
+                event_window_size_, flush_partial);
 
             // Pre-validated "range" of events (euid auto-inc by 1 in the event vector)
             using ConvertToRangeFunction = simdb::pipeline::Function<EventBuffer, EventsRange>;
@@ -285,7 +287,7 @@ namespace pegasus::cosim
             std::cout << "    From disk:  0\n\n";
         }
 
-        //TODO cnyce: Remove this flag when map_v2.1.3 is available
+        // TODO cnyce: Remove this flag when map_v2.1.3 is available
         torn_down_ = true;
     }
 

--- a/cosim/CoSimPipeline.cpp
+++ b/cosim/CoSimPipeline.cpp
@@ -41,7 +41,7 @@ namespace pegasus::cosim
 
         for (HartId hart_id = 0; hart_id < hart_pipelines_.capacity(); ++hart_id)
         {
-            hart_pipelines_.emplace_back(std::make_unique<CoSimHartPipeline>(db_accessor, hart_id));
+            hart_pipelines_.emplace_back(std::make_unique<CoSimHartPipeline>(db_mgr_, db_accessor, hart_id));
             auto hart_pipeline = hart_pipelines_.at(hart_id).get();
 
             pipeline_input_queues_.emplace_back(std::make_unique<simdb::ConcurrentQueue<Event>>());
@@ -67,7 +67,8 @@ namespace pegasus::cosim
                 });
 
             // Run the events through a 100-to-1 buffer
-            auto source_buffer = simdb::pipeline::createTask<simdb::pipeline::Buffer<Event>>(100);
+            constexpr bool flush_partial = true;
+            auto source_buffer = simdb::pipeline::createTask<simdb::pipeline::Buffer<Event>>(100, flush_partial);
 
             // Pre-validated "range" of events (euid auto-inc by 1 in the event vector)
             using ConvertToRangeFunction = simdb::pipeline::Function<EventBuffer, EventsRange>;
@@ -277,6 +278,20 @@ namespace pegasus::cosim
         {
             std::cout << "    From disk:  0\n\n";
         }
+
+        torn_down_ = true;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////
+    size_t CoSimPipeline::getNumCached(HartId hart_id) const
+    {
+        return hart_pipelines_.at(hart_id)->getNumCached();
+    }
+
+    size_t CoSimPipeline::CoSimHartPipeline::getNumCached() const
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return evt_cache_.size();
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////
@@ -291,11 +306,13 @@ namespace pegasus::cosim
 
         if (auto evt = cosim_pipeline_->getEventFromCache_(euid_, hart_id_))
         {
+            ++num_from_cache_;
             return evt;
         }
 
         if (auto evt = cosim_pipeline_->recreateEventFromDisk_(euid_, hart_id_))
         {
+            ++num_from_disk_;
             recreated_evt_ = std::move(evt);
             return recreated_evt_.get();
         }
@@ -360,7 +377,20 @@ namespace pegasus::cosim
         // Run the query on the database thread. It will stop what it is doing
         // as quickly as possible to run this query. The eval() method blocks
         // until the query is picked up and run.
-        async_eval_->eval(query_func);
+        if (!torn_down_)
+        {
+            async_eval_->eval(query_func);
+        }
+        else
+        {
+            // The pipeline has been torn down, so we cannot use async_eval_.
+            // The threads aren't even running anymore. Note that since we
+            // print the pipeline's metrics during teardown, this means that
+            // any events retrieved here will not be counted in the metrics
+            // that are printed to stdout.
+            query_func(db_mgr_);
+        }
+
         if (compressed_evts_range.event_bytes.empty())
         {
             return nullptr;

--- a/cosim/CoSimPipeline.hpp
+++ b/cosim/CoSimPipeline.hpp
@@ -116,8 +116,7 @@ namespace pegasus::cosim
         {
           public:
             CoSimHartPipeline(simdb::DatabaseManager* db_mgr,
-                              simdb::pipeline::AsyncDatabaseAccessor* async_eval,
-                              HartId hart_id) :
+                              simdb::pipeline::AsyncDatabaseAccessor* async_eval, HartId hart_id) :
                 db_mgr_(db_mgr),
                 async_eval_(async_eval),
                 hart_id_(hart_id)

--- a/cosim/CoSimPipeline.hpp
+++ b/cosim/CoSimPipeline.hpp
@@ -69,6 +69,9 @@ namespace pegasus::cosim
         /// Tell us how many internal pipelines to create (one per hart).
         void setNumHarts(size_t num_harts);
 
+        /// Tell us the max number of events to hold in the event cache.
+        void setEventCacheSize(size_t event_window_size);
+
         /// Returns a pipeline configured for fast event processing and retrieval.
         std::unique_ptr<simdb::pipeline::Pipeline>
         createPipeline(simdb::pipeline::AsyncDatabaseAccessor* db_accessor) override;
@@ -198,6 +201,9 @@ namespace pegasus::cosim
 
         /// One "sim stopped" flag per hart.
         std::vector<bool> sim_stopped_;
+
+        /// Max number of events to hold in the event cache.
+        size_t event_window_size_ = DEFAULT_EVENT_WINDOW_SIZE;
 
         /// Snooper which inspects events as they come through the pipeline.
         CoSimPipelineSnooper* snooper_ = nullptr;

--- a/cosim/CoSimPipeline.hpp
+++ b/cosim/CoSimPipeline.hpp
@@ -70,7 +70,7 @@ namespace pegasus::cosim
         void setNumHarts(size_t num_harts);
 
         /// Tell us the max number of events to hold in the event cache.
-        void setEventCacheSize(size_t event_window_size);
+        void setEventWindowSize(size_t event_window_size);
 
         /// Returns a pipeline configured for fast event processing and retrieval.
         std::unique_ptr<simdb::pipeline::Pipeline>

--- a/cosim/CoSimPipeline.hpp
+++ b/cosim/CoSimPipeline.hpp
@@ -97,6 +97,10 @@ namespace pegasus::cosim
         /// Called after the pipeline threads have been flushed and destroyed.
         void postTeardown() override;
 
+        /// Check if the given hart's pipeline has any events cached.
+        /// Used for testing only.
+        size_t getNumCached(HartId hart_id = 0) const;
+
       private:
         friend class EventAccessor;
 
@@ -111,7 +115,10 @@ namespace pegasus::cosim
         class CoSimHartPipeline
         {
           public:
-            CoSimHartPipeline(simdb::pipeline::AsyncDatabaseAccessor* async_eval, HartId hart_id) :
+            CoSimHartPipeline(simdb::DatabaseManager* db_mgr,
+                              simdb::pipeline::AsyncDatabaseAccessor* async_eval,
+                              HartId hart_id) :
+                db_mgr_(db_mgr),
                 async_eval_(async_eval),
                 hart_id_(hart_id)
             {
@@ -145,7 +152,14 @@ namespace pegasus::cosim
             /// Prints metrics about cache/disk retrieval to stdout.
             void postTeardown();
 
+            /// Check if the given hart's pipeline has any events cached.
+            /// Used for testing only.
+            size_t getNumCached() const;
+
           private:
+            /// SimDB instance.
+            simdb::DatabaseManager* db_mgr_ = nullptr;
+
             /// Async DB query object.
             simdb::pipeline::AsyncDatabaseAccessor* async_eval_ = nullptr;
 
@@ -167,6 +181,9 @@ namespace pegasus::cosim
             /// Metrics to print out usage and performance to stdout.
             mutable size_t num_evts_retrieved_from_cache_ = 0;
             simdb::RunningMean avg_microseconds_recreating_evts_;
+
+            /// Flag to let us know if the AsyncDatabaseAccessor can be used.
+            bool torn_down_ = false;
 
             friend class CoSimPipeline;
         };

--- a/cosim/EventAccessor.hpp
+++ b/cosim/EventAccessor.hpp
@@ -47,11 +47,19 @@ namespace pegasus::cosim
         /// Same as operator->().
         const Event* get();
 
+        /// How many times did we have to go to disk to get this event?
+        size_t getNumFromDisk() const { return num_from_disk_; }
+
+        /// How many times did we get this event from the cache?
+        size_t getNumFromCache() const { return num_from_cache_; }
+
       private:
         uint64_t euid_;
         HartId hart_id_;
         CoSimPipeline* cosim_pipeline_ = nullptr;
         std::shared_ptr<Event> recreated_evt_;
+        size_t num_from_disk_ = 0;
+        size_t num_from_cache_ = 0;
     };
 
 } // namespace pegasus::cosim

--- a/cosim/EventAccessor.hpp
+++ b/cosim/EventAccessor.hpp
@@ -2,6 +2,10 @@
 
 #include "include/PegasusTypes.hpp"
 
+/// Events go into the pipeline one at a time, and are buffered for
+/// performance reasons (more zlib compression, fewer DB writes).
+#define DEFAULT_EVENT_WINDOW_SIZE 100
+
 namespace pegasus::cosim
 {
 

--- a/cosim/PegasusCoSim.cpp
+++ b/cosim/PegasusCoSim.cpp
@@ -71,7 +71,7 @@ namespace pegasus::cosim
 
         cosim_pipeline_ = app_mgr_->getApp<CoSimPipeline>();
         cosim_pipeline_->setNumHarts(num_harts);
-        cosim_pipeline_->setEventCacheSize(event_window_size);
+        cosim_pipeline_->setEventWindowSize(event_window_size);
         app_mgr_->openPipelines();
 
         for (uint32_t hart_id = 0; hart_id < num_harts; ++hart_id)

--- a/cosim/PegasusCoSim.cpp
+++ b/cosim/PegasusCoSim.cpp
@@ -45,10 +45,8 @@ namespace pegasus::cosim
         return success;
     }
 
-    PegasusCoSim::PegasusCoSim(sparta::Scheduler* scheduler,
-                               uint64_t ilimit,
-                               const std::string & workload,
-                               const uint32_t event_window_size) :
+    PegasusCoSim::PegasusCoSim(sparta::Scheduler* scheduler, uint64_t ilimit,
+                               const std::string & workload, const uint32_t event_window_size) :
         PegasusSim(scheduler, getWorkloadArgs_(workload), {}, ilimit),
         cosim_logger_(getRoot(), "cosim", "Pegasus Cosim Logger")
     {

--- a/cosim/PegasusCoSim.cpp
+++ b/cosim/PegasusCoSim.cpp
@@ -45,8 +45,10 @@ namespace pegasus::cosim
         return success;
     }
 
-    PegasusCoSim::PegasusCoSim(sparta::Scheduler* scheduler, uint64_t ilimit,
-                               const std::string & workload) :
+    PegasusCoSim::PegasusCoSim(sparta::Scheduler* scheduler,
+                               uint64_t ilimit,
+                               const std::string & workload,
+                               const uint32_t event_window_size) :
         PegasusSim(scheduler, getWorkloadArgs_(workload), {}, ilimit),
         cosim_logger_(getRoot(), "cosim", "Pegasus Cosim Logger")
     {
@@ -71,6 +73,7 @@ namespace pegasus::cosim
 
         cosim_pipeline_ = app_mgr_->getApp<CoSimPipeline>();
         cosim_pipeline_->setNumHarts(num_harts);
+        cosim_pipeline_->setEventCacheSize(event_window_size);
         app_mgr_->openPipelines();
 
         for (uint32_t hart_id = 0; hart_id < num_harts; ++hart_id)

--- a/cosim/PegasusCoSim.hpp
+++ b/cosim/PegasusCoSim.hpp
@@ -41,8 +41,10 @@ namespace pegasus::cosim
     class PegasusCoSim : public PegasusSim, public pegasus::cosim::CoSim
     {
       public:
-        PegasusCoSim(sparta::Scheduler* scheduler, uint64_t ilimit = 0,
-                     const std::string & workload = "");
+        PegasusCoSim(sparta::Scheduler* scheduler,
+                     uint64_t ilimit = 0,
+                     const std::string & workload = "",
+                     const uint32_t event_window_size = DEFAULT_EVENT_WINDOW_SIZE);
 
         ~PegasusCoSim() noexcept;
 

--- a/cosim/PegasusCoSim.hpp
+++ b/cosim/PegasusCoSim.hpp
@@ -41,8 +41,7 @@ namespace pegasus::cosim
     class PegasusCoSim : public PegasusSim, public pegasus::cosim::CoSim
     {
       public:
-        PegasusCoSim(sparta::Scheduler* scheduler,
-                     uint64_t ilimit = 0,
+        PegasusCoSim(sparta::Scheduler* scheduler, uint64_t ilimit = 0,
                      const std::string & workload = "",
                      const uint32_t event_window_size = DEFAULT_EVENT_WINDOW_SIZE);
 

--- a/test/cosim/cosim_workload/step_workload/StepWorkload_test.cpp
+++ b/test/cosim/cosim_workload/step_workload/StepWorkload_test.cpp
@@ -99,7 +99,8 @@ class PipelineEventValidator : public pegasus::cosim::CoSimPipelineSnooper
             auto event = *accessor.get();
             EXPECT_EQUAL(event, event_truth_);
 
-            if (ensure_db_validation) {
+            if (ensure_db_validation)
+            {
                 EXPECT_TRUE(accessor.getNumFromDisk() > 0);
             }
         }


### PR DESCRIPTION
The existing unit tests run too fast to always ensure that some events are accessed after they have been evicted. These changes ensure that the events are also validated after they are definitely out of the cache after flushing the pipeline.