### PR TITLE
Example changes to get FloatFuncs to compile as template parameter (gcc)

### DIFF
--- a/core/inst_handlers/v/RvvFloatInsts.cpp
+++ b/core/inst_handlers/v/RvvFloatInsts.cpp
@@ -38,7 +38,7 @@ namespace pegasus
             pegasus::Action::createAction<
                 &RvvFloatInsts::vfUnaryHandler_<
                     XLEN, OperandMode{.dst = OperandMode::Mode::V, .src2 = OperandMode::Mode::V},
-                    FloatFuncs{f16_sqrt, f32_sqrt, f64_sqrt}>,
+                    FloatFuncs<f16_sqrt, f32_sqrt, f64_sqrt>>,
                 RvvFloatInsts>(nullptr, "vfsqrt.v", ActionTags::EXECUTE_TAG));
 
         inst_handlers.emplace(
@@ -950,7 +950,7 @@ namespace pegasus
         return ++action_it;
     }
 
-    template <typename XLEN, OperandMode opMode, RvvFloatInsts::FloatFuncs funcs, RoundingMode rm>
+    template <typename XLEN, OperandMode opMode, typename funcs, RoundingMode rm>
     Action::ItrType RvvFloatInsts::vfUnaryHandler_(pegasus::PegasusState* state,
                                                    Action::ItrType action_it)
     {
@@ -959,20 +959,20 @@ namespace pegasus
         switch (vector_config->getSEW())
         {
             case 16:
-                if constexpr (funcs.f16 == nullptr)
+                if constexpr (funcs::f16 == nullptr)
                 {
                     sparta_assert(false, "Unsupported SEW value");
                 }
                 else
                 {
                     return vfUnaryHelper<XLEN, 16, opMode,
-                                         [](auto src2) { return func_wrapper(funcs.f16, src2); },
+                                         [](auto src2) { return func_wrapper(funcs::f16, src2); },
                                          rm>(state, action_it);
                 }
                 break;
             case 32:
                 return vfUnaryHelper<XLEN, 32, opMode,
-                                     [](auto src2) { return func_wrapper(funcs.f32, src2); }, rm>(
+                                     [](auto src2) { return func_wrapper(funcs::f32, src2); }, rm>(
                     state, action_it);
 
             case 64:
@@ -981,7 +981,7 @@ namespace pegasus
                               && opMode.src2 != OperandMode::Mode::W)
                 {
                     return vfUnaryHelper<XLEN, 64, opMode,
-                                         [](auto src2) { return func_wrapper(funcs.f64, src2); },
+                                         [](auto src2) { return func_wrapper(funcs::f64, src2); },
                                          rm>(state, action_it);
                 }
             default:

--- a/core/inst_handlers/v/RvvFloatInsts.hpp
+++ b/core/inst_handlers/v/RvvFloatInsts.hpp
@@ -37,7 +37,7 @@ namespace pegasus
         Action::ItrType vfmergeHandler_(pegasus::PegasusState* state_ptr,
                                         Action::ItrType action_it);
 
-        template <typename XLEN6, OperandMode opMode, typename funcs,
+        template <typename XLEN, OperandMode opMode, typename funcs,
                   RoundingMode rm = RoundingMode::DYN>
         Action::ItrType vfUnaryHandler_(pegasus::PegasusState* state_ptr,
                                         Action::ItrType action_it);

--- a/core/inst_handlers/v/RvvFloatInsts.hpp
+++ b/core/inst_handlers/v/RvvFloatInsts.hpp
@@ -19,13 +19,11 @@ namespace pegasus
       public:
         using base_type = RvvFloatInsts;
 
-        template <typename F16, typename F32, typename F64> struct FloatFuncs
+        template <auto F16, auto F32, auto F64> struct FloatFuncs
         {
-            const F16 f16;
-            const F32 f32;
-            const F64 f64;
-
-            constexpr FloatFuncs(F16 f16, F32 f32, F64 f64) : f16(f16), f32(f32), f64(f64) {}
+            static constexpr auto f16 = F16;
+            static constexpr auto f32 = F32;
+            static constexpr auto f64 = F64;
         };
 
         template <typename XLEN>
@@ -39,7 +37,7 @@ namespace pegasus
         Action::ItrType vfmergeHandler_(pegasus::PegasusState* state_ptr,
                                         Action::ItrType action_it);
 
-        template <typename XLEN, OperandMode opMode, FloatFuncs funcs,
+        template <typename XLEN6, OperandMode opMode, typename funcs,
                   RoundingMode rm = RoundingMode::DYN>
         Action::ItrType vfUnaryHandler_(pegasus::PegasusState* state_ptr,
                                         Action::ItrType action_it);


### PR DESCRIPTION
Seems that the existing code is a little incorrect for C++20, at least on gcc. Clang does not have a problem with the current code. I tried out these changes for gcc and clang with C++20 and they both compile.

I only did this for `vfUnaryHelper_()` and commented out everything else, leaving only the "vfsqrt.v" inst handler `emplace` to test it out. Once I saw that compiles fine, I un-commented everything to keep this before-and-after as clean as possible. Ignore the github checks / failures.

This is not really a PR and won't be merged, but it's the clearest way to show the changes that have to be made to address this issue:

https://github.com/sparcians/pegasus/issues/263